### PR TITLE
Upgrade to node20

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
           
       - name: Setup Node
         uses: actions/setup-node@v3.8.1
+        with:
+          node-version: 20
 
       # Compile dist/index.js and bundle with action.yml
       # Force push major and minor tags, e.g. v1, v1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v3.8.1
       with:
-        node-version: 16
+        node-version: 20
     - run: npm ci
     - run: npm test

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
       [Learn more about creating and using encrypted
       secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
     required: false
-    default: '${{ github.token }}'
+    default: ${{ github.token }}
   version:
     description: >-
       PMD version to use. Using "latest" automatically downloads the latest
@@ -86,7 +86,7 @@ outputs:
   violations:
     description: Number of violations found
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: code

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
       "devDependencies": {
         "@actions/io": "^1.1.3",
         "@vercel/ncc": "^0.38.0",
-        "convert-action": "^0.3.0",
         "eslint": "^8.49.0",
         "fetch-mock-jest": "^1.5.1",
         "jest": "^29.6.4",
@@ -2076,36 +2075,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/convert-action": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/convert-action/-/convert-action-0.3.0.tgz",
-      "integrity": "sha512-VGnI3zlCMIIAHnByBKlEv8c66jG5c1UMk1lRfAy64D72btXx+lq24GDdH67fONA4DUm+ySn2FdsR1w1s3FcJ8Q==",
-      "dev": true,
-      "dependencies": {
-        "js-yaml": "^4.1.0"
-      },
-      "bin": {
-        "convert-action": "bin.js"
-      }
-    },
-    "node_modules/convert-action/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/convert-action/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6525,32 +6494,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "convert-action": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/convert-action/-/convert-action-0.3.0.tgz",
-      "integrity": "sha512-VGnI3zlCMIIAHnByBKlEv8c66jG5c1UMk1lRfAy64D72btXx+lq24GDdH67fONA4DUm+ySn2FdsR1w1s3FcJ8Q==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
     },
     "convert-source-map": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint .",
-    "prepare": "npx ncc build lib/index.js --out dist --minify --license licenses.txt && npx convert-action",
+    "prepare": "npx ncc build lib/index.js --out dist --minify --license licenses.txt",
     "test": "jest --coverage",
     "all": "npm run lint && npm run prepare && npm run test"
   },
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@actions/io": "^1.1.3",
     "@vercel/ncc": "^0.38.0",
-    "convert-action": "^0.3.0",
     "eslint": "^8.49.0",
     "jest": "^29.6.4",
     "nock": "^13.3.3",


### PR DESCRIPTION
- also removes convert-action

node20 is available since https://github.com/actions/runner/releases/tag/v2.308.0

node20 will be the next LTS release (https://github.com/nodejs/release#release-schedule)
